### PR TITLE
🐛 fix : Fix excessive resets caused by consecutive ANSI color codes

### DIFF
--- a/src/wexpect/console_reader.py
+++ b/src/wexpect/console_reader.py
@@ -499,7 +499,7 @@ class ConsoleReaderBase:
 
     def process_color_reset(self,line):
         """
-        处理一行中的颜色代码，确保每个 \x1b[{ansi_fg}m 只对应一个最近的 \x1b[0m，
+        处理一行中的颜色代码，确保每个颜色设置组（连续的 \x1b[{ansi_fg}m）只对应一个最近的 \x1b[0m，
         从后往前移除多余的 \x1b[0m。
         
         参数:
@@ -530,9 +530,25 @@ class ConsoleReaderBase:
                         i = j + 1
                     else:
                         # 如果是颜色起始代码（不是 \x1b[0m）
+                        # 检查是否是颜色组的第一个代码
+                        if i == 0 or result and result[-1] != code and not result[-1].startswith('\x1b['):
+                            open_color_count += 1
                         result.append(code)
-                        open_color_count += 1
                         i = j + 1
+                        # 继续检查下一个是否也是颜色代码，如果是则不增加计数
+                        while i < len(line) and line[i:i+2] == '\x1b[':
+                            j = i
+                            while j < len(line) and line[j] != 'm':
+                                j += 1
+                            if j < len(line) and line[j] == 'm':
+                                next_code = line[i:j+1]
+                                if next_code != color_reset:
+                                    result.append(next_code)
+                                    i = j + 1
+                                else:
+                                    break
+                            else:
+                                break
                 else:
                     # 不是完整的 ANSI 代码，按普通字符处理
                     result.append(line[i])


### PR DESCRIPTION
## 动机:

连续的 color badge 实际上只需要一个 reset ，但是按照以前的逻辑，会引入多余 reset.

```python
test_line = """\x1b[30m\x1b[46m 描述文件 \x1b[0m {'title': 'bilili 特性以及使用方法简单介绍', 'show_title': 'bilili 特性以及使用方法简单介绍', 'plot': '最近总有人问我 bilili 怎么用之类的，为了方便我就直接录了个屏，P1 是在 Manjaro 下直接录的，主要介绍 bilili 的特性与用法，P2 是\x1b[0m回到 Windows 录的，添加了一些环境配置的细节，不过懒得剪啦，建议二倍速\\n- BGM：ハイスクール Days\\n- 项目主页：https://github.com/SigureMo/bilili\\n- 文档链接：https://bilili.sigure.xyz/「建议直接访问这个，内容会更详细些」', 'thumb': 'http://i2.hdslb.com/bfs/archive/89528873eb69fca2352238b30b1443b5c03d61d7.jpg', 'premiered': 1596937757, 'dateadded': 1745792225, 'actor': [{'name': '时雨千陌', 'role': 'UP主', 'thumb': 'https://i1.hdslb.com/bfs/face/4b478115588ffc480246c40b41f5ee6628b952a5.jpg', 'profile': 'https://space.bilibili.com/100969474', 'order': 0}], 'genre': ['校园学习'], 'tag': ['下载', 'Python'], 'source': '', 'original_filename': '', 'website': 'https://www.bilibili.com/video/BV1vZ4y1M7mQ', 'chapter_info_data': []}\r\n\x1b[30m\x1b[46m 封面 \x1b[0m http://i2.hdslb.com/bfs/archive/89528873eb69fca2352238b30b1443b5c03d61d7.jpg\r\n\x1b[30m\x1b[46m [2/2] \x1b[0m bilili 环 境配置方法\r\n\x1b[94m INFO \x1b[0m 开始处理视频 bilili 环境配置方法\r\n"""
line = _process_color_reset(test_line)
```

output:

```shell
PS D:\tmp\yutto-uiya> uv run tmp
"\x1b[30m\x1b[46m 描述文件 \x1b[0m {'title': 'bilili 特性以及使用方法简单介绍', 'show_title': 'bilili 特性以及使用方法简单介绍', 'plot': '最近总有人问我 bilili 怎么用之类的，为了方便我就直接录了个屏，P1 是在 Manjaro 下直接录的，主要介绍 bilili 的特性与用法，P2 是\x1b[0m回到 Windows 录的，添加了一些环境配置的细节，不过懒得剪啦，建议二倍速\\n- BGM：ハイスクール Days\\n- 项目主页：https://github.com/SigureMo/bilili\\n- 文档链接：https://bilili.sigure.xyz/「建议直接访问这个，内容会更详细些」', 'thumb': 'http://i2.hdslb.com/bfs/archive/89528873eb69fca2352238b30b1443b5c03d61d7.jpg', 'premiered': 1596937757, 'dateadded': 1745792225, 'actor': [{'name': '时雨千陌', 'role': 'UP主', 'thumb': 'https://i1.hdslb.com/bfs/face/4b478115588ffc480246c40b41f5ee6628b952a5.jpg', 'profile': 'https://space.bilibili.com/100969474', 'order': 0}], 'genre': ['校园学习'], 'tag': ['下载', 'Python'], 'source': '', 'original_filename': '', 'website': 'https://www.bilibili.com/video/BV1vZ4y1M7mQ', 'chapter_info_data': []}\r\n\x1b[30m\x1b[46m 封面 \x1b[0m http://i2.hdslb.com/bfs/archive/89528873eb69fca2352238b30b1443b5c03d61d7.jpg\r\n\x1b[30m\x1b[46m [2/2] \x1b[0m bilili 环 境配置方法\r\n\x1b[94m INFO \x1b[0m 开始处理视频 bilili 环境配置方法\r\n"
```

可以看到有一些多余的 `\x1b[0m` 在内容中没有去除掉。


修复后: 把连续的 color badge 视作一个.

```shell
"\x1b[30m\x1b[46m 描述文件 \x1b[0m {'title': 'bilili 特性以及使用方法简单介绍', 'show_title': 'bilili 特性以及使用方法简单介绍', 'plot': '最近总有人问我 bilili 怎么用之类的，为了方便我就直接录了个屏，P1 是在 Manjaro 下直接录的，主要介绍 bilili 的特性与用法，P2 是\x1b[0m回到 Windows 录的，添加了一些环境配置的细节，不过懒得剪啦，建议二倍速\\n- BGM：ハイスクール Days\\n- 项目主页：https://github.com/SigureMo/bilili\\n- 文档链接：https://bilili.sigure.xyz/「建议直接访问这个，内容会更详细些」', 'thumb': 'http://i2.hdslb.com/bfs/archive/89528873eb69fca2352238b30b1443b5c03d61d7.jpg', 'premiered': 1596937757, 'dateadded': 1745792225, 'actor': [{'name': '时雨千陌', 'role': 'UP主', 'thumb': 'https://i1.hdslb.com/bfs/face/4b478115588ffc480246c40b41f5ee6628b952a5.jpg', 'profile': 'https://space.bilibili.com/100969474', 'order': 0}], 'genre': ['校园学习'], 'tag': ['下载', 'Python'], 'source': '', 'original_filename': '', 'website': 'https://www.bilibili.com/video/BV1vZ4y1M7mQ', 'chapter_info_data': []}\r\n\x1b[30m\x1b[46m 封面 \x1b[0m http://i2.hdslb.com/bfs/archive/89528873eb69fca2352238b30b1443b5c03d61d7.jpg\r\n\x1b[30m\x1b[46m [2/2] \x1b[0m bilili 环 境配置方法\r\n\x1b[94m INFO \x1b[0m 开始处理视频 bilili 环境配置方法\r\n"
```


